### PR TITLE
Add error handling for missing sensors

### DIFF
--- a/sensor.cpp
+++ b/sensor.cpp
@@ -73,7 +73,7 @@ void Sensor::parseSerialData(QString data)
         // Get sensor value
         QString sensorValue = sensorData[1];
 
-        // Update sensor value
+        // Update sensor value if sensor exists
         if (mapPinName.contains(sensorName)) {
             mapPinName[sensorName]->setValue(sensorValue);
         } else {


### PR DESCRIPTION
## Description
- throw error if value from serial monitor doesn't exist in db

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
