### PR TITLE
Add error strings to GlobalErrors class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ add_executable(NewAutoklav
 
   init.sql
   TODO.md
+
 )
 
 target_link_libraries(NewAutoklav

--- a/globalerrors.cpp
+++ b/globalerrors.cpp
@@ -2,6 +2,11 @@
 
 #include "logger.h"
 
+const QString GlobalErrors::DB_ERROR = "Database error occurred";
+const QString GlobalErrors::SERIAL_ERROR = "Serial error occurred";
+const QString GlobalErrors::OLD_DATA_ERROR = "Serial data is old";
+const QString GlobalErrors::SERIAL_SEND_ERROR = "Failed to send serial data";
+
 void GlobalErrors::setError(Error error)
 {
     if (errors.testFlag(error))
@@ -29,10 +34,10 @@ QVector<QString> GlobalErrors::getErrorsString()
 {
     QVector<QString> err;
 
-    if (errors.testFlag(Error::DbError)) err.push_back("Database error occured");
-    if (errors.testFlag(Error::SerialError)) err.push_back("Serial error occured");
-    if (errors.testFlag(Error::OldDataError)) err.push_back("Serial data is old");
-    if (errors.testFlag(Error::SerialSendError)) err.push_back("Failed to send serial data");
+    if (errors.testFlag(Error::DbError)) err.push_back(DB_ERROR);
+    if (errors.testFlag(Error::SerialError)) err.push_back(SERIAL_ERROR);
+    if (errors.testFlag(Error::OldDataError)) err.push_back(OLD_DATA_ERROR);
+    if (errors.testFlag(Error::SerialSendError)) err.push_back(SERIAL_SEND_ERROR);
 
     return err;
 }

--- a/globalerrors.h
+++ b/globalerrors.h
@@ -14,6 +14,11 @@ public:
     };
     Q_DECLARE_FLAGS(Errors, Error);
 
+    static const QString DB_ERROR;
+    static const QString SERIAL_ERROR;
+    static const QString OLD_DATA_ERROR;
+    static const QString SERIAL_SEND_ERROR;
+
     static void setError(Error error);
     static void removeError(Error error);
     static Errors getErrors();

--- a/grpcserver.cpp
+++ b/grpcserver.cpp
@@ -185,10 +185,20 @@ Status GRpcServer::Impl::AutoklavServiceImpl::getSensorValues(grpc::ServerContex
 
     const auto sensorValues = Sensor::getValues();
 
+    // Fetch error flags
+    QVector<QString> errorStrings = GlobalErrors::getErrorsString();
+
+    // If there is a serial error, send abort status
+    for(const QString& errorString : errorStrings){
+        if(errorString == GlobalErrors::SERIAL_ERROR){
+            return Status(grpc::StatusCode::ABORTED, GlobalErrors::SERIAL_ERROR.toStdString());
+        }        
+    }
+    
     replay->set_temp(sensorValues.temp);
     replay->set_tempk(sensorValues.tempK);
     replay->set_pressure(sensorValues.pressure);
-
+    
     return Status::OK;
 }
 

--- a/grpcserver.h
+++ b/grpcserver.h
@@ -4,6 +4,13 @@
 #include <QObject>
 #include <memory>
 
+/**
+ * @brief The GRpcServer class represents a gRPC server.
+ * 
+ * This class is responsible for handling gRPC server operations.
+ * It provides functionality to start and stop the server, as well as
+ * perform other server-related tasks.
+ */
 class GRpcServer : public QObject
 {
     Q_OBJECT
@@ -12,6 +19,12 @@ public:
     ~GRpcServer();
 
 public slots:
+    /**
+     * @brief Shutdowns the gRPC server.
+     * 
+     * This slot is used to gracefully shutdown the gRPC server.
+     * It stops the server and performs any necessary cleanup operations.
+     */
     void shutdown();
 
 private:


### PR DESCRIPTION
## Description
- small constants refactor
- return aborted status if sensor values are fetched while there is serial error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
