### PR TITLE
Refactor Serial class to handle parsing of incoming data

### DIFF
--- a/serial.cpp
+++ b/serial.cpp
@@ -45,22 +45,20 @@ void Serial::readData()
 void Serial::parseData()
 {
     // Find last data instance
-    int endIndex = m_buffer.lastIndexOf(";");
+    int endIndex = m_buffer.lastIndexOf("]");
     if (endIndex == -1)
         return;
 
     // Find beginning of last data instance
-    int startIndex = m_buffer.indexOf(";");
-    if (startIndex == -1)
-        return;
-
-    if (startIndex == endIndex)
+    int startIndex = m_buffer.lastIndexOf("[", endIndex);
+    if (startIndex == -1 || startIndex >= endIndex)
         return;
 
     // Get last data instance
-    QByteArray data = m_buffer.mid(startIndex + 1, endIndex - startIndex - 2);
+    QByteArray data = m_buffer.mid(startIndex + 1, endIndex - startIndex - 1);
+
     // Remove all data except incomplete data
-    m_buffer = m_buffer.mid(endIndex);
+    m_buffer = m_buffer.mid(endIndex + 1);
 
     Sensor::parseSerialData(data);
 }

--- a/serial.h
+++ b/serial.h
@@ -6,7 +6,22 @@
 #include <QSerialPort>
 #include <QTimer>
 
+/**
+ * @brief The Serial class represents a serial communication interface.
+ * 
+ * This class provides methods to open and close the serial port, send data,
+ * and handle incoming data. It also includes functionality to handle reconnection
+ * attempts in case of errors.
+ */
 class Serial : public QObject
+/**
+ * @brief The Serial class represents a serial communication interface.
+ * 
+ * This class provides methods to open and close the serial port, send data, and handle incoming data.
+ * It is implemented as a singleton to ensure that only one instance of the Serial class exists.
+ * 
+ * @note This class is non-copyable and non-movable.
+ */
 {
     Q_OBJECT
 public:
@@ -15,26 +30,54 @@ public:
     Serial(Serial &&) = delete;
     Serial & operator=(Serial &&) = delete;
     ~Serial() = default;
-
     static Serial& instance();
 
+    /**
+     * @brief Opens the serial port.
+     */
     void open();
+
+    /**
+     * @brief Closes the serial port.
+     */
     void close();
+
+    /**
+     * @brief Sends data over the serial port to arduino.
+     * 
+     * @param data The data to be sent over the serial port.
+     */
     void sendData(QString data);
 
 private:
+    /**
+     * @brief Private constructor.
+     * 
+     * @param parent The parent QObject.
+     */
     explicit Serial(QObject *parent = nullptr);
 
+    /**
+     * @brief Parses the incoming data from sensors.
+     */
     void parseData();
 
-    QSerialPort *m_serial = nullptr;
-    QByteArray m_buffer;
-    QTimer m_retryTimer;  // Timer to handle reconnection attempts
-    static constexpr int WAIT_TIME_MS = 5000;
-
+    QSerialPort *m_serial = nullptr; /**< The QSerialPort object for serial communication. */
+    QByteArray m_buffer; /**< The buffer to store incoming data. */
+    QTimer m_retryTimer; /**< The timer to handle reconnection attempts. */
+    static constexpr int WAIT_TIME_MS = 5000; /**< The wait time in milliseconds for reconnection attempts. */
 
 private slots:
+    /**
+     * @brief Slot to read incoming data from the serial port.
+     */
     void readData();
+
+    /**
+     * @brief Slot to handle reconnection attempts when a serial port error occurs.
+     * 
+     * @param error The serial port error.
+     */
     void tryToReconnectWhenErrorAppears(QSerialPort::SerialPortError error);
 
 };


### PR DESCRIPTION
## Description
Wrapped incoming serial data with **`[`** as _start_ and **`]`** as _end_.

It seems to me that sensors below are parsed correctly, didn't touch any calibration yet, just switching trough **GND** and ***5V***
`{
    "temp": 150,
    "tempK": 108.35777126099707,
    "pressure": 3
}`
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
