### PR TITLE
Remove targetK from Global table

### DIFF
--- a/dbmanager.cpp
+++ b/dbmanager.cpp
@@ -43,15 +43,6 @@ QString DbManager::loadGlobal(QString name)
 
 void DbManager::loadGlobals()
 {
-    QString targetKStr = loadGlobal("targetK");
-    if (!targetKStr.isEmpty()) {
-        Globals::targetK = targetKStr.toDouble();
-    }
-    else {
-        Logger::crit(GlobalErrors::DB_GLOBAL_TARGET_K_LOAD_FAILED);
-        GlobalErrors::setError(GlobalErrors::DbTargetKError);
-    }
-
     QString serialDataTimeStr = loadGlobal("serialDataTime");
     if (!serialDataTimeStr.isEmpty()) {
         Globals::serialDataTime = serialDataTimeStr.toInt();

--- a/globalerrors.cpp
+++ b/globalerrors.cpp
@@ -44,7 +44,6 @@ QVector<QString> GlobalErrors::getErrorsString()
 
     // Db error
     if (errors.testFlag(Error::DbError)) err.push_back(DB_ERROR);
-    if (errors.testFlag(Error::DbTargetKError)) err.push_back(DB_GLOBAL_TARGET_K_LOAD_FAILED);
     if (errors.testFlag(Error::DbSerialDataTimeError)) err.push_back(DB_GLOBAL_SERIAL_DATA_TIME_LOAD_FAILED);
     if (errors.testFlag(Error::DbStateMachineTickError)) err.push_back(DB_GLOBAL_STATE_MACHINE_TICK_LOAD_FAILED);
     if (errors.testFlag(Error::DbSterilizationTempError)) err.push_back(DB_GLOBAL_STERILIZATION_TEMP_LOAD_FAILED);

--- a/globalerrors.h
+++ b/globalerrors.h
@@ -8,7 +8,6 @@ class GlobalErrors
 public:
     enum Error {
         DbError =           0x1,
-        DbTargetKError =    0x2,
         DbSerialDataTimeError = 0x4,
         DbStateMachineTickError = 0x8,
         DbSterilizationTempError = 0x10,

--- a/globals.cpp
+++ b/globals.cpp
@@ -2,20 +2,6 @@
 
 #include "dbmanager.h"
 
-bool Globals::setTargetK(double value)
-{
-    if (targetK == value)
-        return true;
-
-    auto& db = DbManager::instance();
-    if (db.updateGlobal("targetK", QString::number(value))) {
-        targetK = value;
-        return true;
-    }
-
-    return false;
-}
-
 bool Globals::setSerialDataTime(int value)
 {
     if (serialDataTime == value)
@@ -75,6 +61,6 @@ bool Globals::setPasterizationTemp(double value)
 Globals::Variables Globals::getVariables()
 {
     return {
-        targetK, serialDataTime, stateMachineTick, sterilizationTemp, pasterizationTemp
+        serialDataTime, stateMachineTick, sterilizationTemp, pasterizationTemp
     };
 }

--- a/globals.h
+++ b/globals.h
@@ -5,20 +5,17 @@ class Globals
 {
 public:
     struct Variables {
-        double targetK;
         int serialDataTime;
         int stateMachineTick;
         double sterilizationTemp;
         double pasterizationTemp;
     };
 
-    inline static double targetK = 0;
     inline static int serialDataTime = 0;
     inline static int stateMachineTick = 0;
     inline static double sterilizationTemp = 0;
     inline static double pasterizationTemp = 0;
 
-    static bool setTargetK(double value);
     static bool setSerialDataTime(int value);
     static bool setStateMachineTick(int value);
     static bool setSterilizationTemp(double value);

--- a/grpcserver.cpp
+++ b/grpcserver.cpp
@@ -108,7 +108,6 @@ Status GRpcServer::Impl::AutoklavServiceImpl::getVariables(grpc::ServerContext *
 
     auto variables = Globals::getVariables();
 
-    replay->set_targetk(variables.targetK);
     replay->set_serialdatatime(variables.serialDataTime);
     replay->set_statemachinetick(variables.stateMachineTick);
     replay->set_sterilizationtemp(variables.sterilizationTemp);
@@ -125,9 +124,7 @@ Status GRpcServer::Impl::AutoklavServiceImpl::setVariable(grpc::ServerContext *c
     const auto value = QString::fromUtf8(request->value().c_str());
 
     bool succ = false;
-    if (name == "targetK") {
-        succ = Globals::setTargetK(value.toDouble());
-    } else if (name == "serialDataTime") {
+    if (name == "serialDataTime") {
         succ = Globals::setSerialDataTime(value.toInt());
     } else if (name == "stateMachineTick") {
         succ = Globals::setStateMachineTick(value.toInt());

--- a/init.sql
+++ b/init.sql
@@ -1,7 +1,6 @@
 -- Globals
 CREATE TABLE Globals ( name TEXT NOT NULL UNIQUE, value TEXT NOT NULL );
 
-INSERT INTO Globals VALUES ( "targetK", "3.5" );
 INSERT INTO Globals VALUES ( "serialDataTime", "3000" );
 INSERT INTO Globals VALUES ( "stateMachineTick", "60000" );
 INSERT INTO Globals VALUES ( "sterilizationTemp", "121.1" );

--- a/proto/autoklav.proto
+++ b/proto/autoklav.proto
@@ -35,11 +35,10 @@ message Status {
 }
 
 message Variables {
-    double targetK = 1;
-    int32 serialDataTime = 2;
-    int32 stateMachineTick = 3;
-    double sterilizationTemp = 4;
-    double pasterizationTemp = 5;
+    int32 serialDataTime = 1;
+    int32 stateMachineTick = 2;
+    double sterilizationTemp = 3;
+    double pasterizationTemp = 4;
 }
 
 message SetVariable {

--- a/readme.md
+++ b/readme.md
@@ -103,10 +103,6 @@ Use QJsonDocument for communication
   "action": "setVariable",
   "data": [
     {
-      "name": "targetK",
-      "value": "5.5"
-    },
-    {
       "name": "cooldown temperature",
       "value": "70"
     }
@@ -158,12 +154,6 @@ Use QJsonDocument for communication
                 "originalValue": 1023
             }
         ],
-        "variables": [
-            {
-                "name": "targetK",
-                "value": 5.5
-            }
-        ],
         "process": {
             "state": 0,
             "name": "ready",
@@ -190,7 +180,6 @@ Use QJsonDocument for communication
         "mode": "steril",
         "logName": "Pasteta 3",
         "data": {
-            "targetK": 5.5,
             "currentK": 3,
         },
         "history": [


### PR DESCRIPTION
## Description
- `targetK` was in Global table by mistake, it wasn't used anywhere and it is confusing statemachine input values

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Tested
- 