### PR TITLE
Remove mapPinName logic and pinNames,

### DIFF
--- a/dbmanager.cpp
+++ b/dbmanager.cpp
@@ -110,13 +110,11 @@ void DbManager::loadSensors()
     QSqlQuery query("SELECT * FROM Sensor", m_db);
     while (query.next()) {
         auto name = query.value(0).toString();
-        auto pinName = query.value(1).toString();
-        auto minValue = query.value(2).toDouble();
-        auto maxValue = query.value(3).toDouble();
+        auto minValue = query.value(1).toDouble();
+        auto maxValue = query.value(2).toDouble();
 
-        Sensor::sensors.append(Sensor(name, pinName, minValue, maxValue));
-        Sensor::mapName.insert(name, &Sensor::sensors.last());
-        Sensor::mapPinName.insert(pinName, &Sensor::sensors.last());
+        Sensor::sensors.append(Sensor(name, minValue, maxValue));
+        Sensor::mapName.insert(name, &Sensor::sensors.last());        
     }
 }
 

--- a/init.sql
+++ b/init.sql
@@ -8,18 +8,23 @@ INSERT INTO Globals VALUES ( "pasterizationTemp", "70.0" );
 
 
 -- Sensor
-CREATE TABLE Sensor ( name TEXT NOT NULL UNIQUE, pinName TEXT NOT NULL UNIQUE, minValue REAL NOT NULL, maxValue REAL NOT NULL );
+create table Sensor
+(
+    name     TEXT not null
+        unique,
+    minValue REAL not null,
+    maxValue REAL not null
+);
 
-INSERT INTO Sensor VALUES ( "temp", "ADC_1", 0, 150 );
-INSERT INTO Sensor VALUES ( "tempK", "ADC_2", 0, 150 );
-INSERT INTO Sensor VALUES ( "pressure", "ADC_3", 0, 3 );
-
-INSERT INTO Sensor VALUES ( "waterFill", "IO_0", 0, 1 );
-INSERT INTO Sensor VALUES ( "heating", "IO_1", 0, 1 );
-INSERT INTO Sensor VALUES ( "bypass", "IO_2", 0, 1 );
-INSERT INTO Sensor VALUES ( "pump", "IO_3", 0, 1 );
-INSERT INTO Sensor VALUES ( "inPressure", "IO_4", 0, 1 );
-INSERT INTO Sensor VALUES ( "cooling", "IO_5", 0, 1 );
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('temp', 0, 150);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('tempK', 0, 150);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('pressure', 0, 3);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('waterFill', 0, 1);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('heating', 0, 1);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('bypass', 0, 1);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('pump', 0, 1);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('inPressure', 0, 1);
+INSERT INTO Sensor (name, minValue, maxValue) VALUES ('cooling', 0, 1);
 
 -- Process
 create table Process

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -11,10 +11,9 @@
 qint64 Sensor::lastDataTime = 0;
 QList<Sensor> Sensor::sensors = QList<Sensor>();
 QMap<QString, Sensor *> Sensor::mapName = QMap<QString, Sensor *>();
-QMap<QString, Sensor *> Sensor::mapPinName = QMap<QString, Sensor *>();
 
-Sensor::Sensor(QString name, QString pinName, double minValue, double maxValue)
-    : name{name}, pinName{pinName}, minValue{minValue}, maxValue{maxValue}
+Sensor::Sensor(QString name, double minValue, double maxValue)
+    : name{name}, minValue{minValue}, maxValue{maxValue}
 {
 
 }
@@ -24,7 +23,7 @@ void Sensor::send(double newValue)
     value = newValue; // Update the internal value
     uint pinValue = (newValue - minValue) / (maxValue - minValue) * 1023;
 
-    auto data = QString("%1=%2").arg(pinName).arg(pinValue);
+    auto data = QString("%1=%2").arg(name).arg(pinValue);
 
     auto &serial = Serial::instance();
     serial.sendData(data);
@@ -125,8 +124,8 @@ void Sensor::parseSerialData(QString data)
         QString sensorValue = sensorData[1];
 
         // Update sensor value if sensor exists
-        if (mapPinName.contains(sensorName)) {
-            mapPinName[sensorName]->setValue(sensorValue);
+        if (mapName.contains(sensorName)) {
+            mapName[sensorName]->setValue(sensorValue);
         } else {
             Logger::crit(QString("Sensor '%1' not found in database.").arg(sensorName));
             GlobalErrors::setError(GlobalErrors::DbError);

--- a/sensor.h
+++ b/sensor.h
@@ -22,7 +22,7 @@ struct SensorRelayValues{
 class Sensor
 {
 public:
-    Sensor(QString name, QString pinName, double minValue, double maxValue);
+    Sensor(QString name, double minValue, double maxValue);
 
     void send(double value);
     void setValue(uint newPinValue);
@@ -34,15 +34,14 @@ public:
     static void parseSerialData(QString data);
     static void checkIfDataIsOld();
     
-    QString name, pinName;
+    QString name;
     double minValue, maxValue;
     double value;
     uint pinValue;
 
     static qint64 lastDataTime;
     static QList<Sensor> sensors;
-    static QMap<QString, Sensor *> mapName;
-    static QMap<QString, Sensor *> mapPinName;
+    static QMap<QString, Sensor *> mapName;    
     static bool updateSensor(QString name, double minValue, double maxValue);
 };
 

--- a/serial.cpp
+++ b/serial.cpp
@@ -3,6 +3,7 @@
 #include "sensor.h"
 #include "logger.h"
 #include "globalerrors.h"
+#include "qthread.h"
 
 #include <QTimer>
 
@@ -111,9 +112,10 @@ void Serial::close()
 
 void Serial::sendData(QString data)
 {
-    data.append(";");
-
+    data.append(";");    
     auto succ = m_serial->write(data.toUtf8());
+    m_serial->flush();
+    QThread::msleep(3000);
 
     if (succ == -1)
         GlobalErrors::setError(GlobalErrors::SerialSendError);

--- a/statemachine.cpp
+++ b/statemachine.cpp
@@ -127,7 +127,7 @@ StateMachineValues StateMachine::calculateDrFrRValuesFromSensorsOnTheFly()
 }
 
 void StateMachine::tick()
-{    
+{
     if (isRunning()) {
         values = calculateDrFrRValuesFromSensors(process->getId());
     } else {


### PR DESCRIPTION
## Description
- hardcode names with pinValues on arduino, backend should only use names since arduino needs manual updating of memory keeping values in sql db makes no sens
-
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Tested
- frontend