### PR TITLE
Add serial communication redundancy

### DIFF
--- a/serial.cpp
+++ b/serial.cpp
@@ -122,18 +122,20 @@ void Serial::sendData(const QString& data)
     }
 
     auto succ = m_serial->write(protocolData.toUtf8());
+    // Add a small delay to prevent overwhelming the Arduino
+    QThread::msleep(5000); // Adjust the delay as necessary
+
     if (succ == -1) {
         Logger::crit("Failed to send data via serial");
         GlobalErrors::setError(GlobalErrors::SerialSendError);
     } else {
-        if (!m_serial->waitForBytesWritten(2000)) {  // Wait 1000 ms for data to be sent
+        if (!m_serial->waitForBytesWritten(5000)) {  // Wait 5000 ms for data to be sent
             Logger::crit("Failed to send data via serial (timeout)");
             GlobalErrors::setError(GlobalErrors::SerialSendError);
         } else {
             GlobalErrors::removeError(GlobalErrors::SerialSendError);
-            // Add a small delay to prevent overwhelming the Arduino
-            QThread::msleep(100); // Adjust the delay as necessary
-        }
+
+        }        
     }
 }
 

--- a/statemachine.cpp
+++ b/statemachine.cpp
@@ -146,7 +146,7 @@ void StateMachine::controlRelays(std::initializer_list<std::pair<const char*, in
         auto data = dataParts.join("");
 
         auto& serial = Serial::instance();
-        serial.sendData(data); // Send all relay data as a single message
+        serial.sendData(data); // Send all relay data as a single message        
     }
 
 }


### PR DESCRIPTION
## Description

- improve serial communication by reducing sending time to arduino to prevent being overwhelmed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Tested
- arudino, next, qt