### PR TITLE
Expand statemachine logic

### DIFF
--- a/statemachine.h
+++ b/statemachine.h
@@ -19,7 +19,7 @@ public:
     ~StateMachine() = default;
 
     enum State {
-        READY, STARTING, FILLING, PRESSURING, HEATING, COOLING, FINISHING, FINISHED
+        READY, STARTING, FILLING, HEATING, COOLING, FINISHING, FINISHED
     };
 
     enum Type {


### PR DESCRIPTION
## Description
- not finished
- didn't contact Pikec yet but coding makes sense, I will come up with more questions in a few days and ask them in one shot 
- separate `tick` for controlling `tank` is overflowing serial communication on arduino, I will have to find different solution than sleeping thread before sending, I will study those threads and resolve them in the end 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Tested
- not yet