### PR TITLE
Add stopManualProcess RPC method to Autoklav service

### DIFF
--- a/grpcserver.cpp
+++ b/grpcserver.cpp
@@ -169,9 +169,9 @@ Status GRpcServer::Impl::AutoklavServiceImpl::startProcess(grpc::ServerContext *
 {
     Q_UNUSED(context);
 
-    //TODO   add target heating time
     const StateMachine::ProcessConfig processConfig = {
         .type = static_cast<StateMachine::Type>(request->processconfig().type()),
+        .heatingType = static_cast<StateMachine::HeatingType>(request->processconfig().heatingtype()),
         .customTemp = request->processconfig().customtemp(),
         .mode = static_cast<StateMachine::Mode>(request->processconfig().mode()),        
         .maintainTemp = request->processconfig().maintaintemp(),

--- a/proto/autoklav.proto
+++ b/proto/autoklav.proto
@@ -144,6 +144,11 @@ enum ProcessConfigType {
     CUSTOM = 2;
 }
 
+enum HeatingType {
+    STEAM = 0;
+    ELECTRIC = 1;
+}
+
 enum ProcessConfigState {
     READY = 0;
     STARTING = 1;
@@ -161,10 +166,11 @@ enum ProcessConfigMode {
 
 message ProcessConfig {
     ProcessConfigType type = 1;
-    double customTemp = 2;
-    ProcessConfigMode mode = 3;       
-    double maintainTemp = 4;
-    double finishTemp = 5;    
+    HeatingType heatingType = 2;
+    double customTemp = 3;
+    ProcessConfigMode mode = 4;
+    double maintainTemp = 5;
+    double finishTemp = 6;    
 }
 
 message ProcessInfo {

--- a/statemachine.h
+++ b/statemachine.h
@@ -30,8 +30,13 @@ public:
         TARGETF, TIME
     };
 
+    enum HeatingType {
+        STEAM, ELECTRIC
+    };
+
     struct ProcessConfig {
         Type type;
+        HeatingType heatingType;
         double customTemp;
         Mode mode;        
         double maintainTemp;


### PR DESCRIPTION
## Description
- support heating switch 
- add manual stop for autoklav

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Tested
