### PR TITLE
Add setRelayStatus and setStateMachineState RPC methods

### DIFF
--- a/proto/autoklav.proto
+++ b/proto/autoklav.proto
@@ -31,6 +31,8 @@ service Autoklav {
 
     // StateMachine
     rpc getStateMachineValues(Empty) returns (StateMachineValues);
+    rpc setRelayStatus(SetVariable) returns (Status);    
+    rpc setStateMachineState(SetState) returns (Status);    
 }
 
 message Empty {}
@@ -153,14 +155,8 @@ enum HeatingType {
     ELECTRIC = 1;
 }
 
-enum ProcessConfigState {
-    READY = 0;
-    STARTING = 1;
-    FILLING = 2;
-    HEATING = 3;
-    COOLING = 4;
-    FINISHING = 5;
-    FINISHED = 6;
+message SetState {
+    uint32 state = 1;
 }
 
 enum ProcessConfigMode {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -29,6 +29,20 @@ void Sensor::send(double newValue)
     Serial::instance().sendData(data);
 }
 
+bool Sensor::setRelayState(QString name, uint value)
+{
+    // Update sensor value if sensor exists
+    if (mapName.contains(name)) {        
+        Sensor::mapName[name]->send(value);    
+    } else {
+        Logger::crit(QString("Sensor '%1' cannot be set to '%2' since it is not found in database.").arg(name).arg(value));
+        GlobalErrors::setError(GlobalErrors::DbError);
+        return false;
+    }
+
+    return true;
+}
+
 void Sensor::sendIfNew(double newValue)
 {
     if (newValue == value)

--- a/sensor.h
+++ b/sensor.h
@@ -49,6 +49,7 @@ public:
     static SensorValues getValues();
     static SensorValues getPinValues();
     static SensorRelayValues getRelayValues();
+    static bool setRelayState(QString name, uint value);
     static void parseSerialData(QString data);
     static void checkIfDataIsOld();
     

--- a/statemachine.cpp
+++ b/statemachine.cpp
@@ -369,6 +369,17 @@ void StateMachine::autoklavControl()
     }
 }
 
+bool StateMachine::setState(uint newState)
+{
+    // Check if newState is within the valid range of the enum
+    if (newState >= READY && newState <= FINISHED) {
+        this->state = static_cast<State>(newState);
+        return true;  // State change successful
+    }
+
+    return false;  // Invalid state, return false
+}
+
 StateMachine &StateMachine::instance()
 {
     static StateMachine _instance;

--- a/statemachine.h
+++ b/statemachine.h
@@ -44,9 +44,10 @@ public:
     };
 
     bool start(ProcessConfig processConfig, ProcessInfo processInfo);
+    bool setState(uint newState);
     bool stop();
     bool isRunning();
-    int getState();
+    int getState();    
 
     StateMachineValues getValues();
     StateMachineValues calculateStateMachineValues();


### PR DESCRIPTION
## Description
- add setter for state and relays, finally!

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Tested
